### PR TITLE
ITAI-3584 - allow space as a thousand separator

### DIFF
--- a/Duckling/AmountOfMoney/EN/Corpus.hs
+++ b/Duckling/AmountOfMoney/EN/Corpus.hs
@@ -59,6 +59,12 @@ allExamples = concat
              , "10 dollars"
              , "ten dollars"
              ]
+  , examples (simple Dollar 10000)
+             [ "10k"
+			 , "10000$"
+			 , "10 000 $"
+			 , "10 000,00 $"
+             ]
   , examples (simple Cent 10)
              [ "10 cent"
              , "ten pennies"

--- a/Duckling/Numeral/EN/Corpus.hs
+++ b/Duckling/Numeral/EN/Corpus.hs
@@ -98,6 +98,7 @@ allExamples = concat
              [ "100,000"
              , "100,000.0"
              , "100000"
+			 , "100 000"
              , "100K"
              , "100k"
              , "one hundred thousand"

--- a/Duckling/Numeral/EN/Rules.hs
+++ b/Duckling/Numeral/EN/Rules.hs
@@ -250,6 +250,33 @@ ruleDecimals = Rule
       _ -> Nothing
   }
 
+ruleDecimalWithThousandsSeparator :: Rule
+ruleDecimalWithThousandsSeparator = Rule
+  { name = "decimal with thousands separator"
+  , pattern =
+    [ regex "(\\d+(([ ])\\d\\d\\d)+[\\.,]\\d+)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_:sep:_)):
+       _) -> let fmt = Text.replace "," "." $ Text.replace sep Text.empty match
+        in parseDouble fmt >>= double
+      _ -> Nothing
+  }
+
+ruleIntegerWithThousandsSeparator :: Rule
+ruleIntegerWithThousandsSeparator = Rule
+  { name = "integer with thousands separator ."
+  , pattern =
+    [ regex "(\\d{1,3}(([ ])\\d\\d\\d){1,5})"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_:sep:_)):
+       _) -> let fmt = Text.replace sep Text.empty match
+        in parseDouble fmt >>= double
+      _ -> Nothing
+  }
+
+
 ruleCommas :: Rule
 ruleCommas = Rule
   { name = "comma-separated numbers"
@@ -354,7 +381,9 @@ ruleLegalParentheses = Rule
 
 rules :: [Rule]
 rules =
-  [ ruleToNineteen
+  [ ruleDecimalWithThousandsSeparator
+  , ruleIntegerWithThousandsSeparator
+  , ruleToNineteen
   , ruleTens
   , rulePowersOfTen
   , ruleCompositeTens


### PR DESCRIPTION
[ITAI-3584](https://qtravel.atlassian.net/browse/ITAI-3584)

## Description

Changes based on https://github.com/facebook/duckling/commit/b2de97800f658d8492a9d48820c2887d6ce89f1b#diff-e0d24a1f0de617195de17fd003d360e9943c757383d1d87ef99436dc81a185ea

Adds space as a thousand separator for `EN` language.

## How to test
run queries:
- from 1 000 to 3 000 €
- 2 500 euro

[ITAI-3584]: https://qtravel.atlassian.net/browse/ITAI-3584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ